### PR TITLE
Feature/use watchlist

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -207,57 +207,63 @@ npm-fiso globals ./watchlist.txt -
 npm-fiso project ./watchlist.txt -
 ```
 
+## Bundled watchlists (aliases)
+
+This package includes ready-to-use watchlists under `watchlists/` and exposes simple **aliases** so you don't have to compute paths:
+
+- `@bundled/<name>`  (e.g. `@bundled/common`)
+- `bundled:<name>`   (e.g. `bundled:angular`)
+
+The `.txt` extension is optional.
+
+**Examples**
+```bash
+# Project mode (print to STDOUT)
+npm-fiso project @bundled/common -
+
+# Globals mode
+npm-fiso globals bundled:angular -
+---
+
+Here’s a **README section** you can drop in, showing the bundled watchlists in a table and linking to the repo file. I used your current path **`watchlist/npm_160925.txt`** and provided alias examples.
+
+---
+
 ## Bundled watchlists
 
-This package ships with a set of **predefined watchlists** under:
+These watchlists ship with the package and can be referenced by **path** or by **alias** (`@bundled/<name>` or `bundled:<name>`, with optional `.txt`).
 
-```
-node_modules/npm-fiso/watchlists/
-```
+> **Folder:** `watchlist/` (included in the npm package via `"files"`)
 
-You can pass any of these files as the `watchlist` argument (first CLI parameter), just like you would with your own files.
+| Alias                 | File path                  | Description                           | View in repo                                                                         |
+| --------------------- | -------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `@bundled/npm_160925` | `watchlist/npm_160925.txt` | Snapshot watchlist (dated 2025-09-16) | [Open file](https://github.com/dani-b-g/npm-fiso/blob/main/watchlist/npm_160925.txt) |
 
-### Using a bundled watchlist (project mode)
+### Usage examples
 
-**If `npm-fiso` is installed locally** (dev dependency):
-
-```bash
-npm-fiso project ./node_modules/npm-fiso/watchlists/<file>.txt -
-```
-
-**If `npm-fiso` is installed globally**, compute the absolute path:
+**Project mode (print to STDOUT)**
 
 ```bash
-# macOS/Linux (bash/zsh)
-WATCHLIST="$(npm root -g)/npm-fiso/watchlists/<file>.txt"
+# Using alias
+npm-fiso project @bundled/npm_160925 -
+
+# Using direct path (when installed locally)
+npm-fiso project ./node_modules/npm-fiso/watchlist/npm_160925.txt -
+```
+
+**Globals mode**
+
+```bash
+# Using alias
+npm-fiso globals bundled:npm_160925 -
+
+# Using absolute path (cross-platform via Node resolution)
+WATCHLIST="$(node -p "require('path').join(require('path').dirname(require.resolve('npm-fiso/package.json')), 'watchlist', 'npm_160925.txt')")"
 npm-fiso globals "$WATCHLIST" -
 ```
 
-**Cross-platform (macOS/Linux/Windows) via Node resolution:**
+> Tip: The `.txt` extension is optional when using aliases (e.g., `@bundled/npm_160925`).
 
-```bash
-# macOS/Linux (bash/zsh)
-WATCHLIST=$(node -p "require('path').join(require('path').dirname(require.resolve('npm-fiso/package.json')), 'watchlists', '<file>.txt')")
-npm-fiso project "$WATCHLIST" -
-
-# Windows PowerShell
-$watchlist = Join-Path (Split-Path (node -p "require('path').dirname(require.resolve('npm-fiso/package.json'))")) "watchlists\<file>.txt"
-npm-fiso project $watchlist -
-```
-
-### Listing bundled files
-
-```bash
-# macOS/Linux
-node -e "const fs=require('fs'),p=require('path');const base=p.dirname(require.resolve('npm-fiso/package.json'));console.log(fs.readdirSync(p.join(base,'watchlists')).join('\n'));"
-
-# Windows PowerShell
-node -e "const fs=require('fs'),p=require('path');const base=p.dirname(require.resolve('npm-fiso/package.json'));console.log(fs.readdirSync(p.join(base,'watchlists')).join('\n'));"
-```
-
-> Tip: When using `npx npm-fiso ...`, you can still compute the path at runtime using the Node snippet above and pass it to the CLI.
-
----
 
 
 ## License

--- a/bin/npm-fiso.js
+++ b/bin/npm-fiso.js
@@ -19,34 +19,29 @@ Usage:
   npm-fiso -h | --help
 
 Arguments:
-  watchlist   Path to the watchlist file, or "-" for STDIN.
+  watchlist   Path to the watchlist file, "-" for STDIN,
+              or a bundled alias:
+                - @bundled/<name>   (e.g. @bundled/common)
+                - bundled:<name>    (e.g. bundled:angular)
+              ".txt" is optional and added if missing.
               Default: ./watchlist.txt
   output      Path to the output file, or "-" for STDOUT.
               Default: ./matches.txt
 
 Output format:
-  # Matches (global|project npm)    root_package    trace_to_affected
-  npm    <root>@<version>    <root>@<version> > ... > <match>@<version>
+  # Matches (global|project npm)\troot_package\ttrace_to_affected
+  npm\t<root>@<version>\t<root>@<version> > ... > <match>@<version>
 
 Examples:
+  # From a regular file:
   npm-fiso globals ./watchlist.txt ./out.txt
-  cat list.txt | npm-fiso project - -
 
-Bundled watchlists:
-  This package includes ready-to-use watchlists under:
-    node_modules/npm-fiso/watchlists/
+  # Using bundled aliases (file lives in package's watchlists/):
+  npm-fiso project @bundled/common -
+  npm-fiso globals bundled:angular -
 
-You can pass them as the first argument (watchlist). Examples:
-
-    # Local install (project)
-    npm-fiso project ./node_modules/npm-fiso/watchlists/<file>.txt -
-
-    # Global install (bash/zsh)
-    WATCHLIST="$(npm root -g)/npm-fiso/watchlists/<file>.txt"
-    npm-fiso globals "$WATCHLIST" -
-
-    # Cross-platform (compute absolute path at runtime)
-    node -p "require('path').join(require('path').dirname(require.resolve('npm-fiso/package.json')), 'watchlists', '<file>.txt')"
+  # Pipe:
+  cat watchlist.txt | npm-fiso project - -
 `);
 }
 


### PR DESCRIPTION
# Changelog
All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

---

## [1.1.0] - 2025-09-18
### Added
- **Bundled watchlist aliases**: you can pass `@bundled/<name>` or `bundled:<name>` (with optional `.txt`) as the `watchlist` argument and it resolves to the package’s bundled list.
- **README – Bundled watchlists section**: added a table listing the shipped watchlist(s) and direct link to the file in the repo.
  - Current entry: `watchlist/npm_160925.txt` → linked in README.
- **CLI help** now documents bundled aliases and usage examples for both modes.

### Docs
- English-first README with clear usage, input/output requirements, examples, and troubleshooting.

---

## [1.0.0] - 2025-09-18
### Added
- **CLI `npm-fiso`** with two subcommands:
  - `globals`: scans global npm dependencies using `npm ls -g --all --json`.
  - `project`: scans the current project using `npm ls --all --json`.
- **Full tree traversal** (toplevel + transitivas) and **trace output**:
  - Output includes the **root package** and the **trace**:  
    `root@version > … > matched@version`.
- **Watchlist parser**:
  - Supports `name@version`, multiple versions per line separated by commas, `name version` (space), and name-only (match any version).
- **I/O**:
  - Watchlist from **file** or **STDIN** (`-`).
  - Results to **file** or **STDOUT** (`-`).
- **Packaging**:
  - `bin/npm-fiso.js` as executable.
  - Whitelisted files for npm publish (`bin`, `src`, `README.md`, `LICENSE`, y la carpeta `watchlist/`).
  - `engines: { "node": ">=14" }`.

### Changed
- **License** switched to **MIT**.

---

[1.1.0]: https://github.com/dani-b-g/npm-fiso/compare/v1.0.0...v1.1.0